### PR TITLE
[SUGESTÃO] Adicionar arquivo para Pipeline Azure DevOps - Modo clássico do Azure descontinuado

### DIFF
--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -1,0 +1,60 @@
+trigger:
+- main
+
+variables:
+  serviceConnectionName: 'azure-terraform-sp'           
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+# ==============================================
+# 1. Autenticação no Azure via Service Connection
+# ==============================================
+- task: AzureCLI@2
+  inputs:
+    azureSubscription: $(serviceConnectionName)
+    scriptType: 'bash'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      echo "Verificando autenticação..."
+      az account show  # Testa se a conexão está ativa
+
+# ==============================================
+# 2. Execução do Terraform (com variáveis de ambiente)
+# ==============================================
+- script: |
+    echo "Versão do Terraform:"
+    terraform --version
+    
+    echo "Inicializando Terraform..."
+    terraform init
+  displayName: 'Init Terraform'
+  workingDirectory: 'terraform/'
+  env:
+    ARM_CLIENT_ID: #Coloque aqui o seu Application (client) ID criado no AD Azure (Service Principal).
+    ARM_CLIENT_SECRET: #Coloque aqui a chave criada no momento da criação do AD (Service Principal).
+    ARM_TENANT_ID: #Coloque aqui o seu Directory (tenant) ID criado no AD Azure (Service Principal).
+    ARM_SUBSCRIPTION_ID: #Coloque aqui o ID da SUBSCRIPTION que está usando.
+
+- script: |
+    echo "Planejando mudanças..."
+    terraform plan -out=tfplan
+  displayName: 'Plan Terraform'
+  workingDirectory: 'terraform/'
+  env:
+    ARM_CLIENT_ID: #Coloque aqui o seu Application (client) ID criado no AD Azure (Service Principal).
+    ARM_CLIENT_SECRET: #Coloque aqui a chave criada no momento da criação do AD (Service Principal).
+    ARM_TENANT_ID: #Coloque aqui o seu Directory (tenant) ID criado no AD Azure (Service Principal).
+    ARM_SUBSCRIPTION_ID: #Coloque aqui o ID da SUBSCRIPTION que está usando.
+
+- script: |
+    echo "Aplicando configuração..."
+    terraform apply -auto-approve tfplan
+  displayName: 'Apply Terraform'
+  workingDirectory: 'terraform/'
+  env:
+    ARM_CLIENT_ID: #Coloque aqui o seu Application (client) ID criado no AD Azure (Service Principal).
+    ARM_CLIENT_SECRET: #Coloque aqui a chave criada no momento da criação do AD (Service Principal).
+    ARM_TENANT_ID: #Coloque aqui o seu Directory (tenant) ID criado no AD Azure (Service Principal).
+    ARM_SUBSCRIPTION_ID: #Coloque aqui o ID da SUBSCRIPTION que está usando.


### PR DESCRIPTION
Olá Alexsandro, bom dia! Estou mandando essa sugestão pois, o modo clássico do Azure DevOps foi descontinuado, atualmente a única maneira de criar pipelines na plataforma DevOps da Azure é por meio do arquivo YAML. O Layout antigo foi totalmente mudado forçando o usúario a usar YAML para criar os seus pipelines. Acabei de terminar o projeto do DevOps Fundamentals, sofri bastante para aprender, muitos erros, mas consegui então decidi mandar o arquivo para a criação do pipeline que eu fiz e usei no projeto. Dessa forma, possibilitando que seja uma jornada mais fácil para todos que no futuro decidam fazer o curso e o projeto.
Desde já agradeço, felicidades e paz!